### PR TITLE
Use Expo tunnel for default dev workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "expo start",
-    "start": "expo start",
+    "dev": "expo start --tunnel",
+    "start": "expo start --tunnel",
     "tunnel": "expo start --tunnel",
     "build:web": "expo export --platform web",
     "lint": "expo lint"


### PR DESCRIPTION
## Summary
- update the default `dev` and `start` scripts to launch Expo with the tunnel host so Expo Go can connect from mobile devices

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e68da2b2548331b1ec342e7546d3a6