### PR TITLE
Align Expo dependencies for Expo Go compatibility

### DIFF
--- a/app.json
+++ b/app.json
@@ -7,7 +7,7 @@
     "icon": "./assets/images/icon.png",
     "scheme": "myapp",
     "userInterfaceStyle": "automatic",
-    "newArchEnabled": true,
+    "newArchEnabled": false,
     "platforms": ["ios", "android", "web"],
     "ios": {
       "supportsTablet": true,

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['nativewind/babel'],
+  };
+};

--- a/nativewind-env.d.ts
+++ b/nativewind-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="nativewind/types" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,10 @@
         "@react-native-community/slider": "5.0.1",
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/native": "^7.0.14",
-        "expo": "^54.0.12",
+        "expo": "~54.0.0",
         "expo-apple-authentication": "~8.0.7",
         "expo-av": "~16.0.7",
         "expo-blur": "~15.0.7",
-        "expo-camera": "~17.0.8",
         "expo-constants": "~18.0.9",
         "expo-file-system": "~19.0.16",
         "expo-font": "~14.0.8",
@@ -37,9 +36,10 @@
         "expo-system-ui": "~6.0.7",
         "expo-web-browser": "~15.0.8",
         "lucide-react-native": "^0.468.0",
+        "nativewind": "^4.0.1",
         "react": "19.1.0",
         "react-dom": "19.1.0",
-        "react-native": "0.81.4",
+        "react-native": "0.78.4",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-reanimated": "~4.1.1",
         "react-native-safe-area-context": "~5.6.0",
@@ -48,7 +48,8 @@
         "react-native-url-polyfill": "^2.0.0",
         "react-native-video": "^6.16.1",
         "react-native-web": "^0.21.0",
-        "react-native-webview": "13.15.0"
+        "react-native-webview": "13.15.0",
+        "tailwindcss": "^3.4.1"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -5069,26 +5070,6 @@
         "expo": "*",
         "react": "*",
         "react-native": "*"
-      }
-    },
-    "node_modules/expo-camera": {
-      "version": "17.0.8",
-      "resolved": "https://registry.npmjs.org/expo-camera/-/expo-camera-17.0.8.tgz",
-      "integrity": "sha512-BIGvS+3myaYqMtk2VXWgdcOMrewH+55BttmaYqq9tv9+o5w+RAbH9wlJSt0gdaswikiyzoWT7mOnLDleYClXmw==",
-      "license": "MIT",
-      "dependencies": {
-        "invariant": "^2.2.4"
-      },
-      "peerDependencies": {
-        "expo": "*",
-        "react": "*",
-        "react-native": "*",
-        "react-native-web": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-web": {
-          "optional": true
-        }
       }
     },
     "node_modules/expo-constants": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "expo start",
-    "start": "expo start",
+    "dev": "expo start --tunnel",
+    "start": "expo start --tunnel",
     "tunnel": "expo start --tunnel",
     "build:web": "expo export --platform web",
     "lint": "expo lint"
@@ -18,11 +18,10 @@
     "@react-native-community/slider": "5.0.1",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
-    "expo": "^54.0.12",
+    "expo": "~54.0.0",
     "expo-apple-authentication": "~8.0.7",
     "expo-av": "~16.0.7",
     "expo-blur": "~15.0.7",
-    "expo-camera": "~17.0.8",
     "expo-constants": "~18.0.9",
     "expo-file-system": "~19.0.16",
     "expo-font": "~14.0.8",
@@ -40,9 +39,10 @@
     "expo-system-ui": "~6.0.7",
     "expo-web-browser": "~15.0.8",
     "lucide-react-native": "^0.468.0",
+    "nativewind": "^4.0.1",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "react-native": "0.81.4",
+    "react-native": "0.78.4",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
@@ -52,7 +52,8 @@
     "react-native-url-polyfill": "^2.0.0",
     "react-native-video": "^6.16.1",
     "react-native-web": "^0.21.0",
-    "react-native-webview": "13.15.0"
+    "react-native-webview": "13.15.0",
+    "tailwindcss": "^3.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,12 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: [
+    './app/**/*.{js,jsx,ts,tsx}',
+    './components/**/*.{js,jsx,ts,tsx}',
+    './constants/**/*.{js,jsx,ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- align the Expo and React Native dependency versions for Expo Go compatibility and drop the unused camera package
- add NativeWind configuration (Babel plugin, Tailwind config, TypeScript types) and disable the new architecture flag for a safer default

## Testing
- not run (npm install blocked by registry 403)


------
https://chatgpt.com/codex/tasks/task_e_68e68da2b2548331b1ec342e7546d3a6